### PR TITLE
linux: disable DEBUG_PREEMPT and PREEMPT_DYNAMIC for ~9% MT perf gain

### DIFF
--- a/linux/config
+++ b/linux/config
@@ -127,7 +127,7 @@ CONFIG_PREEMPT=y
 # CONFIG_PREEMPT_RT is not set
 CONFIG_PREEMPT_COUNT=y
 CONFIG_PREEMPTION=y
-CONFIG_PREEMPT_DYNAMIC=y
+# CONFIG_PREEMPT_DYNAMIC is not set
 # CONFIG_SCHED_CORE is not set
 
 #
@@ -12516,7 +12516,7 @@ CONFIG_SCHED_INFO=y
 CONFIG_SCHEDSTATS=y
 # end of Scheduler Debugging
 
-CONFIG_DEBUG_PREEMPT=y
+# CONFIG_DEBUG_PREEMPT is not set
 
 #
 # Lock Debugging (spinlocks, mutexes, etc...)


### PR DESCRIPTION
## Summary

- Disable `CONFIG_DEBUG_PREEMPT` — adds runtime preemption count checks, useful for development but overhead in production
- Disable `CONFIG_PREEMPT_DYNAMIC` — adds indirect call overhead at every preemption point for runtime model switching, which is unused since `CONFIG_PREEMPT=y` is already selected

No functional change: the kernel still runs in full preemption mode (`CONFIG_PREEMPT=y`), just without the debug checks and dynamic dispatch overhead.

## Benchmark results

Tested on Rock 5B+ (RK3588), BredOS, identical 6.19.1 kernel source, `governor=performance`, method: `openssl speed -evp {sha256,aes-256-cbc} [-multi 8]`

### Multi-thread (8 threads)

| Algorithm | PREEMPT (static) | PREEMPT_DYNAMIC + DEBUG | Delta |
|-----------|:-:|:-:|:-:|
| SHA256 16384B | ~9,200 kB/s | ~8,400 kB/s | **+~9%** |
| AES-256-CBC 16384B | ~8,300 kB/s | ~7,600 kB/s | **+~9%** |

### Single-thread

No measurable difference — single-threaded workloads are not affected.

### Why multi-thread only?

`DEBUG_PREEMPT` adds lock/assertion checks on preemption count changes. `PREEMPT_DYNAMIC` uses indirect calls (`CALL *`) instead of direct calls at preemption points. Both costs compound under contention — i.e. when multiple cores compete for shared resources — which is why the improvement manifests in multi-threaded workloads.

## Risk

Low. Both options are debug/flexibility features with no impact on supported functionality:
- `DEBUG_PREEMPT` is explicitly a debug option (`depends on DEBUG_KERNEL` in Kconfig)
- `PREEMPT_DYNAMIC` only provides the ability to switch preemption model at boot via `preempt=` parameter, which BredOS does not use